### PR TITLE
Also propagate the comments

### DIFF
--- a/src/IniWriter.php
+++ b/src/IniWriter.php
@@ -92,6 +92,9 @@ class IniWriter
                     $value = array($value);
                 }
 
+                // adding comments
+                $ini .= $this->addComments($comments, $sectionName, $option);
+
                 if (is_array($value)) {
                     foreach ($value as $currentValue) {
                         $ini .= $option . '[] = ' . $this->encodeValue($currentValue) . "\n";
@@ -105,6 +108,26 @@ class IniWriter
         }
 
         return $ini;
+    }
+
+    private function addComments($comments, $sectionName, $option) {
+        $result = "";
+
+        if (isset($comments[$sectionName][$option])) {
+            $comment = explode("\n", $comments[$sectionName][$option]);
+            array_pop($comment);
+            $next = array_shift($comment);
+            while ($next !== null) {
+                if ($next === "") {
+                    $result .= "\n";
+                } else {
+                    $result .= "; " . $next . "\n";
+                }
+                $next = array_shift($comment);
+            }
+        }
+
+        return $result;
     }
 
     private function encodeValue($value)


### PR DESCRIPTION
Adding the possibility to also propagate the comments when writing the ini file. Works as follows:

$ini = 'piwik.ini';
$reader = new \Piwik\Ini\IniReader();
$config = $reader->readFile($ini);
$comments = $reader->readComments($ini);
$writer = new \Piwik\Ini\IniWriter();
$writer->writeToFile('piwik-new.ini', $config, '', $comments);

Things that do not work:

1 pre-section comments disappear:
  ; section comment
  [MySection]
  ; option comment
  myOption = 1

becomes
  [MySection]
  ; option comment
  myOption = 1

2 Individual array comments disappear:
  [MySection]
  ; comment a
  ar[] = "a"
  ; comment b
  ar[] = "b"
  ; comment c
  ar[] = "c"

becomes
  [MySection]
  ; comment a
  ar[] = "a"
  ar[] = "b"
  ar[] = "c"